### PR TITLE
fix: allow props as abbreviation

### DIFF
--- a/index.js
+++ b/index.js
@@ -346,6 +346,16 @@ module.exports = {
     'unicorn/no-unsafe-regex': 'off',
     'unicorn/no-unused-properties': 'warn',
     'unicorn/no-zero-fractions': 'off',
+    'unicorn/prevent-abbreviations': [
+      'error',
+      {
+        replacements: {
+          props: {
+            properties: false,
+          },
+        },
+      },
+    ],
     'unicorn/prefer-export-from': 'off',
     'unicorn/prefer-includes': 'off',
     'unicorn/prefer-module': 'warn',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new ESLint rule to improve code clarity by preventing the use of abbreviations.
	- Enforced the use of the term "properties" instead of the abbreviation "props" to enhance maintainability and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->